### PR TITLE
Added variable callback for lazy access objects properties

### DIFF
--- a/src/Grammar/JavaScript/JavaScript.php
+++ b/src/Grammar/JavaScript/JavaScript.php
@@ -42,7 +42,7 @@ final class JavaScript extends Grammar
             [Token::COMMENT, '//[^\r\n]*|/\*.*?\*/', 25],
             [Token::NEWLINE, '\r?\n', 20],
             [Token::SPACE, '\s+', 15],
-            [Token::VARIABLE, '[a-zA-Z_]\w*', 10],
+            [Token::VARIABLE, '\b[a-zA-Z0-9_]*[a-zA-Z0-9_\.]*[a-zA-Z0-9_]+(?!\()\b', 10],
             [Token::UNKNOWN, '.', 5],
         ];
     }

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -23,13 +23,13 @@ class Rule
     /** @var object */
     private static $container;
 
-    public function __construct(string $rule, array $variables = [])
+    public function __construct(string $rule, array $variables = [], callable $variableCallback = null)
     {
         if (!isset(self::$container)) {
             self::$container = require __DIR__ . '/container.php';
         }
 
-        $this->parser = self::$container->parser($variables);
+        $this->parser = self::$container->parser($variables, $variableCallback);
         $this->rule = $rule;
     }
 

--- a/src/container.php
+++ b/src/container.php
@@ -36,10 +36,10 @@ return new class {
     /** @var Evaluator */
     private static $evaluator;
 
-    public function parser(array $variables): Parser\Parser
+    public function parser(array $variables, callable $variableCallback = null): Parser\Parser
     {
         return new Parser\Parser(
-            self::ast($variables),
+            self::ast($variables, $variableCallback),
             self::expressionFactory(),
             self::compiler()
         );
@@ -72,10 +72,11 @@ return new class {
         return self::$compiler;
     }
 
-    private static function ast(array $variables): AST
+    private static function ast(array $variables, callable $variableCallback = null): AST
     {
         $ast = new AST(self::tokenizer(), self::tokenFactory(), self::tokenStreamFactory(), self::userMethodFactory());
         $ast->setVariables($variables);
+        $ast->registerVariableCallback($variableCallback);
 
         return $ast;
     }

--- a/tests/integration/RuleTest.php
+++ b/tests/integration/RuleTest.php
@@ -30,13 +30,43 @@ final class RuleTest extends TestCase
 
         $vars = [
             'foo' => 5,
-            'bar' => 7
+            'bar' => 7,
         ];
 
         $rule = new Rule\Rule($string, $vars);
 
         $this->assertTrue($rule->isTrue());
         $this->assertTrue(!$rule->isFalse());
+    }
+
+    /** @test */
+    public function variableCallback()
+    {
+        $string = 'foo.bar === 10 && bar.foo === 5 && foo.bar > bar.foo2 && a === 10';
+        $map = [
+            'foo.bar' => 10,
+            'bar.foo' => 5,
+            'bar.foo2' => 1,
+            'a' => 10,
+        ];
+        $rule = new Rule\Rule($string, [], function (string $name) use ($map) {
+            return $map[$name];
+        });
+        $this->assertTrue($rule->isTrue());
+    }
+
+    /** @test */
+    public function stringVariableCallback()
+    {
+        $string = 'foo.bar === "a@b.c" && bar.foo === \'https://ab.c\' ';
+        $map = [
+            'foo.bar' => 'a@b.c',
+            'bar.foo' => 'https://ab.c',
+        ];
+        $rule = new Rule\Rule($string, [], function (string $name) use ($map) {
+            return $map[$name];
+        });
+        $this->assertTrue($rule->isTrue());
     }
 
     /** @test */


### PR DESCRIPTION
This PR adds:
- Ability to use dots in the variable names, e.g `foo.bar`
- If the variable is not defined it will call the provided user callback which resolves the variable value.

So that the following code would work:
```
use Symfony\Component\PropertyAccess\PropertyAccessor;

$rule = new Rule('foo.bar > 10 && foo.bar < 20', [], function(string $name) {
    $propertyAccessor = new PropertyAccessor();
    if (false !== strpos($name, '.')) {
        [$entity, $field] = explode('.', $name);
        if ($entity === 'foo') {
            return $propertyAccessor->getValue($object, $field);
        }
    }
    throw new \OutOfBoundsException("Unable to resolve variable '{$name}'");
});
$rule->isTrue();
```